### PR TITLE
Remove conversion to 4-byte int

### DIFF
--- a/bbb/oderhs.m
+++ b/bbb/oderhs.m
@@ -8602,8 +8602,7 @@ c     factorization routine sgbco from Linpack/SLATEC.
             call xerrab("")
          endif
          tsmatfac = gettime(sec4)
-         call sgbco (wp, lowd, INT(neq,4), INT(lbw,4), INT(ubw,4),
-     ,               iwp(4), rcond, rwk1)
+         call sgbco (wp, lowd, neq, lbw, ubw, iwp(4), rcond, rwk1)
          iwp(1) = lowd
          iwp(2) = lbw
          iwp(3) = ubw


### PR DESCRIPTION
Arguments `lda` and `n` passed to subroutine [`dgbco_u`](https://github.com/LLNL/UEDGE/blob/master/svr/daux1.f#L655) can get messed up by conversion from 8-byte to 4-byte int inside subroutine [`jac_lu_decomp`](https://github.com/LLNL/UEDGE/blob/master/bbb/oderhs.m#L8605). In certain cases I've been working with, this eventually causes a segfault during the "Updating Jacobian" step of solving. The solution is not to convert to 4-byte int.