### PR TITLE
Make Checkver more resilient to failures

### DIFF
--- a/src/uedge/checkver.py
+++ b/src/uedge/checkver.py
@@ -1,38 +1,28 @@
-
-import json
-
-pkg = 'uedge'
+pkg = "uedge"
 
 try:
-   import importlib.metadata
-   thisver = importlib.metadata.version(pkg)
-except:
-   import pkg_resources
-   thisver = pkg_resources.get_distribution(pkg).version
+    import json
+    import urllib.request
 
-try:
-   import urllib.request
-   contents = urllib.request.urlopen('https://pypi.org/pypi/'+pkg+'/json').read()
-   data = json.loads(contents.decode())
-   thatver = data['info']['version']
-except:
-   import urllib
-   contents = urllib.urlopen('https://pypi.org/pypi/'+pkg+'/json').read()
-   data = json.loads(contents)
-   thatver = str(data['info']['version'])
+    try:
+        import importlib.metadata
 
+        thisver = importlib.metadata.version(pkg)
+    except:
+        import pkg_resources
 
-if thisver > thatver:
-   #print('Uedge version '+thisver+' is newer than available with pip ('+thatver+')')
-   pass
-elif thisver == thatver:
-   #print('Uedge version '+thisver+' is up-to-date')
-   pass
-elif thisver < thatver:
-   print()
-   print('Uedge version '+thisver+', an update is available to '+thatver)
-   print()
-else:
-   print()
-   print('Some error checking pypi version')
-   print()
+        thisver = pkg_resources.get_distribution(pkg).version
+
+    contents = urllib.request.urlopen("https://pypi.org/pypi/" + pkg + "/json").read()
+    data = json.loads(contents.decode())
+    thatver = data["info"]["version"]
+
+    if thisver < thatver:
+        print()
+        print("Uedge version " + thisver + ", an update is available to " + thatver)
+        print()
+
+except Exception as err:
+    print()
+    print("Error checking pypi version: {}".format(err))
+    print()


### PR DESCRIPTION
The checkver code fails if https is not available, preventing UEDGE from running. 
This fix makes the version check more resilient to failures.

- Wrap the whole thing in a try...except, printing the error message
- Remove the fallback to python2 urllib, as python2 is not supported
- Tidy up, removing conditional branches that are not used.