### PR TITLE
Adds X-point core boundary cell width routine

### DIFF
--- a/grd/grd.v
+++ b/grd/grd.v
@@ -572,6 +572,9 @@ slpxffd2	real
 nxdff2		integer		/0/
 	# number of cells between flame front and divertor plate
 	# on outer leg (region 2)
+mincorecellwidth integer /1/    # Switch to set min cell width in core around X-point
+mindist(1:2)  _real   /0.005/   # Minimum cell width at X-point core cut
+maxdist(1:2)  _real  /0.01/     # Minimum cell width at X-point sep. cut
 
 ***** Refinex:
 # data used for mesh refinement near the x-point

--- a/grd/grd.v
+++ b/grd/grd.v
@@ -572,7 +572,7 @@ slpxffd2	real
 nxdff2		integer		/0/
 	# number of cells between flame front and divertor plate
 	# on outer leg (region 2)
-mincorecellwidth integer /1/    # Switch to set min cell width in core around X-point
+mincorecellwidth integer /0/    # Switch to set min cell width in core around X-point
 mindist(1:2)  _real   /0.005/   # Minimum cell width at X-point core cut
 maxdist(1:2)  _real  /0.01/     # Minimum cell width at X-point sep. cut
 


### PR DESCRIPTION
Implements control over poloidal spacing near X-point to allow narrow cells along the separatrix, while maintaining a minimum poloidal distance at the core boundary. Particularly useful when the core boundary is at small Psi_n. 

mincorecellwidht [0(default)/1] - switch whether to limit poloidal cell size near X-point
mindist [float, 0.005(default)] - minimum poloidal width of cells on core boundary cells in m
maxdist [float, 0.01(default)] - minimum poloidal width of cells near X-point in m