### PR TITLE
Feature/v9 develop vnm

### DIFF
--- a/bbb/bbb.v
+++ b/bbb/bbb.v
@@ -67,6 +67,8 @@ cfrecom   real            /1./ +input
 igas      integer         /0/     +input #=1 invokes local rate eqn. for ng
 ngbackg(ngspmx) real [1/m**3] /ngspmx*1.e14/ +input 
                                   #background gas density
+cfbackg(ngspmx) real          /ngspmx*1./ +input
+                                  #..zml background gas source rescale factor
 ingb      integer         /2/     +input 
                                   #background gas source=nuiz*ngbackg*
                                   #                  (.9+.1*(ngbackg/ng)**ingb)
@@ -858,6 +860,63 @@ cftgtipltl(ngspmx)  real   /ngspmx*1./    +threadprivate #left plate Tg B.C.: tg
 cftgtipltr(ngspmx)  real   /ngspmx*1./    +threadprivate #right plate Tg B.C.: tg = cftgtipltr*ti if istgrb=5
 cgengmpl  real		 /1./   +input #scale fac mol plate eng loss for Maxw
 cgengmw  real		 /1./   +input #scale fac mol wall eng loss for Maxw
+isvacuummodel(ngspmx)     integer /6*0/ +input #user:(=0) default model for neutral outer boundary conditions
+                                               #     (=1) using DEGAS2-calculated tele-transport matrix, half-Mxwellian for outgoing neutrals
+                                               #     (=2)                                                CX-diffusion for outgoing neutrals
+                                               #     (=3)                                                combination for outgoing neutrals
+cftelematrix(0:nx+1,0:nx+1,ngspmx) _real /0./ +maybeinput # tele-transport matrix if isvacuummodel > 0
+cfpuffmatrix(0:nx+1,ngspmx)             _real /0./ +maybeinput # placeholder for puffing matrix if isvacuummodel > 0
+                                                               # assuming point puff source, so, the matrix shape is (1,nx)
+cfteleout  real         /1./    +input # scale fac tele-transport neutral source for half-Maxw
+fngyteleout(0:nx+1,ngspmx)              _real      # flux of tele-transport neutral going out of the outer boundary,
+fngytelein(0:nx+1,ngspmx)               _real      # flux of tele-transport neutral coming back into the outer boundary,
+	                                           # = fngyteleout*cftelematrix
+fngytelemaxw(0:nx+1,ngspmx)             _real      # flux of tele-transport neutral going out of the outer boundary, assuming half-Maxw
+fngytelediff(0:nx+1,ngspmx)             _real      # flux of tele-transport neutral going out of the outer boundary, assuming CX diffusion
+                                                   # Three compoments: fngytelediff1 + fngytelediff2 + fngytelediff3
+                                                   # 1) fngytelediff1 = c1*ng
+                                                   # 2) fngytelediff2 = c2*dng/dtau, where dng/dtau is gradient of ng parallel to the wall
+                                                   # 3) fngytelediff3 = c3*dng/dnu,  where dng/dnu  is gradient of ng along the wall normal
+fngytelediff1(0:nx+1,ngspmx)             _real     # first component of fngytelediff
+fngytelediff2(0:nx+1,ngspmx)             _real     # second component of fngytelediff
+fngytelediff3(0:nx+1,ngspmx)             _real     # third component of fngytelediff
+fngytelediff30(0:nx+1,ngspmx)             _real     # third component of fngytelediff before applying limiter
+cftelelim  real     [m] /1./   +input # scale factor for fngytelediff3 limiter, limiting the maximum fngytelediff3 below lambda_i/lambda_n ~ 1.0
+ntelelim   real         /2./   +input # exponent for fngytelediff3 limiter
+lteleout   real     [m] /1./   +input # scale length used to calculate neutral Knusen number, Kn = lmfp/lteleout
+Kn(0:nx+1,ngspmx)           _real     # Knusen number at the outer boundary, = lmfpn/lteleout, where lmfpn = sqrt(Tg/mg)/nucx
+Knb1       real         /0.01/ +input # lower bound of Knusen number
+Knb2       real         /1./  +input # upper bound of Knusen number
+                                      # if Kn <= Knb1, fngyteleout = fngytelediff
+                                      # else if Kn >= Knb2, fngyteleout = fngytelemaxw
+                                      # else   fngyteleout = c1*fngytelemaxw + c2*fngytelediff
+                                      #       where c1 = (Kn-Knb1)/(Knb2-Knb1), and c2 = 1-c1
+fmgyteleout(0:nx+1,ngsp)   _real      # mom. flux of tele-transport neutral going out of the outer boundary,
+fmgytelein(0:nx+1,ngsp)    _real      # mom. flux of tele-transport neutral coming back into the outer boundary,
+                                      # = 0. for current model, assuming wall absorb all the mom. and energy
+fmgytelemaxw(0:nx+1,ngsp)  _real      # mom. flux of tele-transport neutral going out of the outer boundary, assuming half-Maxw
+                                      # fegytelemaxw = fngytelemaxw*mu_p
+fmgytelediff(0:nx+1,ngsp)  _real      # mom. flux of tele-transport neutral going out of the outer boundary, assuming CX diffusion
+                                      # Three compoments: fmgytelediff1 + fmgytelediff2 + fmgytelediff3
+                                      # 1) fmgytelediff1 = fngytelediff1*mu_p
+                                      # 2) fmgytelediff2 = fngytelediff2*mu_p + 'something' ('something' ignored for current model)
+                                      # 3) fmgytelediff3 = fngytelediff3*mu_p
+fmgytelediff1(0:nx+1,ngsp)  _real     # first component of fmgytelediff
+fmgytelediff2(0:nx+1,ngsp)  _real     # second component of fmgytelediff
+fmgytelediff3(0:nx+1,ngsp)  _real     # third component of fmgytelediff
+fegyteleout(0:nx+1,ngsp)   _real      # eng. flux of tele-transport neutral going out of the outer boundary,
+fegytelein(0:nx+1,ngsp)    _real      # eng. flux of tele-transport neutral coming back into the outer boundary,
+                                      # = 0. for current model, assuming wall absorb all the mom. and energy
+fegytelemaxw(0:nx+1,ngsp)  _real      # eng. flux of tele-transport neutral going out of the outer boundary, assuming half-Maxw
+                                      # fegytelemaxw = fngytelemaxw*(0.5mu_p^2 + 2T), omit 0.5mu_p^2 for internal
+fegytelediff(0:nx+1,ngsp)  _real      # eng. flux of tele-transport neutral going out of the outer boundary, assuming CX diffusion
+                                      # Three compoments: fegytelediff1 + fegytelediff2 + fegytelediff3
+                                      # 1) fegytelediff1 = fngytelediff1*(0.5mu_p^2 + 2Ti), omit 0.5mu_p^2 for internal
+                                      # 2) fegytelediff2 = fngytelediff2*(0.5mu_p^2 + 5/2Ti), omit 0.5mu_p^2 for internal
+                                      # 3) fegytelediff3 = fngytelediff3*(0.5mu_p^2 + 5/2Ti), omit 0.5mu_p^2 for internal
+fegytelediff1(0:nx+1,ngsp)  _real     # first component of fegytelediff
+fegytelediff2(0:nx+1,ngsp)  _real     # second component of fegytelediff
+fegytelediff3(0:nx+1,ngsp)  _real     # third component of fegytelediff
 
 ***** Outpwall:
 # Arrays used to communicate wall fluxes to a wall simulation code

--- a/bbb/bbb.v
+++ b/bbb/bbb.v
@@ -68,7 +68,7 @@ igas      integer         /0/     +input #=1 invokes local rate eqn. for ng
 ngbackg(ngspmx) real [1/m**3] /ngspmx*1.e14/ +input 
                                   #background gas density
 cfbackg(ngspmx) real          /ngspmx*1./ +input
-                                  #..zml background gas source rescale factor
+                                  # background gas source rescale factor
 ingb      integer         /2/     +input 
                                   #background gas source=nuiz*ngbackg*
                                   #                  (.9+.1*(ngbackg/ng)**ingb)

--- a/bbb/odesetup.m
+++ b/bbb/odesetup.m
@@ -6715,6 +6715,19 @@ c   Check model switches for UEDGE updates/bugs
             write(*,*) "atom energy equation. "
             write(*,*) ""
       endif
+      #if (isvacuummodel(1) .gt. 0) then  #..zml: add warning messages, but not sure where is the best place to add
+      #      write(*,*) ""
+      #      write(*,*) ""
+      #      write(*,*) "           **** WARNING ****"
+      #      write(*,*) "You are using neutral vacuum transport model with isvacuummodel > 0"
+      #      if (isvacuummodel(1) .gt. 0) then
+      #           write(*,*) "You set isvacuummodel(1) > 1, a DEGAS2 pre-calculated tele-transport matrix is required"
+      #      endif
+      #      write(*,*) "Here is your current tele-transport Matrix"
+      #      if (cftelematrix(1,1,1) .eq. 0.0) then
+      #          write(*,*) "All elements are ZEROS, you HAVE NOT set up your tele-transport matrix cftelematrix"
+      #      endif
+      #endif
 
 c...    TODO: checks used to be on nigmx, a local parameter set in
 c...        pandf while these checks were located there. Checks moved

--- a/bbb/odesetup.m
+++ b/bbb/odesetup.m
@@ -6715,7 +6715,7 @@ c   Check model switches for UEDGE updates/bugs
             write(*,*) "atom energy equation. "
             write(*,*) ""
       endif
-      #if (isvacuummodel(1) .gt. 0) then  #..zml: add warning messages, but not sure where is the best place to add
+      #if (isvacuummodel(1) .gt. 0) then  # add warning messages, but not sure where is the best place to add
       #      write(*,*) ""
       #      write(*,*) ""
       #      write(*,*) "           **** WARNING ****"

--- a/bbb/pandf_boundary.m
+++ b/bbb/pandf_boundary.m
@@ -2420,10 +2420,11 @@ c  ###################################################################
       Use(Gradients)
       Use(Interp)
       integer ifld, ix, iv1, ii, jx, iv2, iimp, iv, ix1, nzsp_rt, igsp,
-     .  jz, igsp2, iv3, ix3, ix4, iy, ixt
+     .  jz, igsp2, iv3, ix3, ix4, iy, ixt, ix2
       real wsmo, vyn, fng_chem, flx_incid, nharmave, fng_alb, 
      .  albe, fniy_recy, nbound, tbound, fngyw, eng_sput, yld96, 
      .  yld_chm, cfalbe, vxn, flux_inc, ta0, vxa, zflux
+      real Mi_nu,Mi_taunu,Mi_nunu,dng2dnu,dng2dtau,lmfpn,fteledifftrim,fngytelelim
       real ave, t0,t1
       ave(t0,t1) = 2*t0*t1 / (cutlo+t0+t1)
 
@@ -2436,6 +2437,63 @@ c...  now do the iy = ny+1 boundary
 c...  if extrapolation b.c.on outer wall, isextrw=1, otherwise isextrw=0
       if (j7 .ge. (ny+1)-isextrnw .or. j7 .ge. (ny+1)-isextrtw) then
       do ifld = 1 , nisp
+        if (isupgon(1) .eq. 1 .and. zi(ifld) .eq. 0.0 .and. isvacuummodel(1) .gt. 0) then
+          do ix = i4+1-ixmnbcl, i8-1+ixmxbcl   #..compute fngyteleout
+              # half-Maxwellian
+              t0 = max(tg(ix,ny,1),tgmin*ev)
+              vyn = sqrt( 0.5*t0/(pi*mi(ifld)) )
+              fngytelemaxw(ix,1) = cfteleout*ni(ix,ny,ifld)*vyn*sy(ix,ny)
+              # CX diffusion
+              ix1 = ixm1(ix,ny)
+              ix2 = ixp1(ix,ny)
+              t1 = max(ti(ix,ny),temin*ev)
+              Mi_nu = -sqrt( 0.5*t1/(pi*mi(1)) )
+              Mi_taunu = -0.5*( up(ix,ny,0)*rrv(ix,ny) + up(ix1,ny,0)*rrv(ix1,ny) )*Mi_nu  # = Utau*Mi_nu
+              Mi_nunu = 0.5*t0/mi(1)
+              dng2dnu = -0.5*( (ngy1(ix,ny,1) - ngy0(ix,ny,1))/dynog(ix,ny)
+     .                     + (ngy1(ix,ny-1,1) - ngy0(ix,ny-1,1))/dynog(ix,ny-1) )
+              dng2dtau = -0.5*( (ng(ix2,ny,1) - ng(ix,ny,1))*gxf(ix,ny)
+     .                        + (ng(ix,ny,1) - ng(ix1,ny,1))*gxf(ix1,ny) )
+              fngytelediff1(ix,1) = - nucx(ix,ny,1)/(nucx(ix,ny,1)+nuiz(ix,ny,1)) *
+     .                                ng(ix,ny,1)*Mi_nu * sy(ix,ny)
+              fngytelediff2(ix,1) =   nucx(ix,ny,1)/(nucx(ix,ny,1)+nuiz(ix,ny,1))**2 *
+     .                                dng2dtau*Mi_taunu * sy(ix,ny)
+              fngytelediff30(ix,1) =   nucx(ix,ny,1)/(nucx(ix,ny,1)+nuiz(ix,ny,1))**2 *
+     .                                dng2dnu*Mi_nunu * sy(ix,ny)
+              # The third component is dominant in divertor regions and can cause numerical instability
+              # We add a flux limiter to this term fngytelediff3,
+              # where the constant 1.2533 is a result of pi/sqrt(2*pi)
+              fngytelelim = cftelelim * 1.2533*abs(nucx(ix,ny,1)/(nucx(ix,ny,1)+nuiz(ix,ny,1))*ng(ix,ny,1)*Mi_nu * sy(ix,ny))
+              fngytelediff3(ix,1) = fngytelediff30(ix,1)/
+     .                              (1 + (abs(fngytelediff30(ix,1)/fngytelelim))**ntelelim )**(1./ntelelim)
+              fngytelediff(ix,1) = cfteleout * (fngytelediff1(ix,1) +
+     .                                          fngytelediff2(ix,1) + fngytelediff3(ix,1))
+              fteledifftrim = max(fngytelediff(ix,1),0.)  # Trim to avoid negative influx
+              if (isvacuummodel(1) .eq. 1) then  # half-Maxwellian
+                fngyteleout(ix,1) = fngytelemaxw(ix,1)
+              elseif (isvacuummodel(1) .eq. 2) then  # CX diff, Eq.(3.88) in AFN manual from KU Lueven
+                fngyteleout(ix,1) = fteledifftrim
+              elseif (isvacuummodel(1) .eq. 3) then
+                lmfpn = sqrt(t0/mi(ifld))/nucx(ix,ny,1)
+                Kn(ix,1) = lmfpn/lteleout
+                if (Kn(ix,1) <= Knb1) then
+                    fngyteleout(ix,1) = fteledifftrim
+                elseif (Kn(ix,1) >= Knb2) then
+                    fngyteleout(ix,1) = fngytelemaxw(ix,1)
+                else
+                    fngyteleout(ix,1) = (Kn(ix,1)-Knb1)/(Knb2-Knb1)*fngytelemaxw(ix,1) +
+     .                                  (Knb2-Kn(ix,1))/(Knb2-Knb1)*fteledifftrim
+                endif
+              else
+                write (*,*) 'isvacuummodel > 3 not available, placeholder for future extention'
+              endif
+          enddo
+          do ix = 0, nx+1   #..compute fngytelein
+              t0 = max(tg(ix,ny,1),tgmin*ev)
+              vyn = sqrt( 0.5*t0/(pi*mi(ifld)) )
+              fngytelein(ix,1) = sum(fngyteleout(:,1)*cftelematrix(:,ix,1))
+          enddo
+        endif
         do ix = i4+1-ixmnbcl, i8-1+ixmxbcl
           if (isnionxy(ix,ny+1,ifld)==1) then
             iv1 = idxn(ix,ny+1,ifld)
@@ -2456,6 +2514,7 @@ c ---  typically hydrogen only, so DIVIMP chem sputt not used here
                 nharmave = 2.*(ni(ix,ny,ifld)*ni(ix,ny+1,ifld)) /
      ,                        (ni(ix,ny,ifld)+ni(ix,ny+1,ifld))
                 fng_alb = (1-albedoo(ix,1))*nharmave*vyn*sy(ix,ny)
+                if (isvacuummodel(1) .gt. 0) fng_alb = fngyteleout(ix,1) - fngytelein(ix,1)
                 yldot(iv1) = nurlxg*( fniy(ix,ny,ifld) - fng_alb + 
      .                             fng_chem ) / (vyn*sy(ix,ny)* n0(ifld))
 
@@ -2547,20 +2606,58 @@ c...  Do the parallel velocity BC along iy = ny+1
          do ix = i4+1-ixmnbcl, i8-1+ixmxbcl
             if (isuponxy(ix,ny+1,ifld)==1) then
                iv2 = idxu(ix,ny+1,ifld)
-               if (isupwoix(ix,ifld)==1) then  #zero parallel momentum flux
-                  yldot(iv2) = nurlxu * fmiy(ix,ny,ifld) / 
+               if (isupgon(1) .eq. 1 .and. zi(ifld) .eq. 0.0 .and. isvacuummodel(1) .gt. 0) then
+                 ix1 = ixm1(ix,ny)
+                 # Maxwellian
+                 fmgytelemaxw(ix,1) = 0.5*fngytelemaxw(ix,1)*mg(1)*(up(ix,ny,ifld)+up(ix1,ny,ifld))
+                 # CX diffusion
+                 fmgytelediff1(ix,1) = 0.5*fngytelediff1(ix,1)*mg(1)*(up(ix,ny,ifld)+up(ix1,ny,ifld))
+                 fmgytelediff2(ix,1) = 0.5*fngytelediff2(ix,1)*mg(1)*(up(ix,ny,ifld)+up(ix1,ny,ifld)) #..approximation, omitting small terms
+                 fmgytelediff3(ix,1) = 0.5*fngytelediff3(ix,1)*mg(1)*(up(ix,ny,ifld)+up(ix1,ny,ifld))
+                 fmgytelediff(ix,1) = cfteleout*(fmgytelediff1(ix,1) + fmgytelediff2(ix,1) + fmgytelediff3(ix,1))
+                 # Trim diffusion to avoid negative influx
+                 if (fngytelediff(ix,1) .gt. 0.) then
+                   fteledifftrim = fmgytelediff(ix,1)
+                 else
+                   fteledifftrim = 0.
+                 endif
+                 # compute fmgyteleout
+                 if (isvacuummodel(1) .eq. 1) then
+                   fmgyteleout(ix,1) = fmgytelemaxw(ix,1)
+                 elseif (isvacuummodel(1) .eq. 2) then
+                   fmgyteleout(ix,1) = fteledifftrim
+                 elseif (isvacuummodel(1) .eq. 3) then
+                   if (Kn(ix,1) <= Knb1) then
+                     fmgyteleout(ix,1) = fteledifftrim
+                   elseif (Kn(ix,1) >= Knb2) then
+                     fmgyteleout(ix,1) = fmgytelemaxw(ix,1)
+                   else
+                     fmgyteleout(ix,1) = (Kn(ix,1)-Knb1)/(Knb2-Knb1)*fmgytelemaxw(ix,1) +
+     .                                   (Knb2-Kn(ix,1))/(Knb2-Knb1)*fteledifftrim
+                   endif
+                 else
+                   write (*,*) 'isvacuummodel > 3 not available, placeholder for future extention'
+                 endif
+                 # place holder for momentu influx fmgytelein
+                 fmgytelein(ix,1) = 0.
+                 yldot(iv2) = nurlxu * (fmiy(ix,ny,ifld) - (fmgyteleout(ix,1)-fmgytelein(ix,1)))/
      .                                 (vpnorm*sy(ix,ny)*fnorm(ifld))
-               elseif (isupwoix(ix,ifld)==2) then  #  d(up)/dy = 0
-                  yldot(iv2) = nurlxu * nm(ix,ny,ifld) / fnorm(ifld) *
-     .                           (up(ix,ny,ifld) - up(ix,ny+1,ifld))
-               elseif (isupwoix(ix,ifld)==3) then  # d(up)/dy = up/lyup
-                  yldot(iv2) = -nurlxu * nm(ix,ny,ifld) / fnorm(ifld) *
+               else
+                 if (isupwoix(ix,ifld)==1) then  #zero parallel momentum flux
+                    yldot(iv2) = nurlxu * fmiy(ix,ny,ifld) / 
+     .                                   (vpnorm*sy(ix,ny)*fnorm(ifld))
+                 elseif (isupwoix(ix,ifld)==2) then  #  d(up)/dy = 0
+                    yldot(iv2) = nurlxu * nm(ix,ny,ifld) / fnorm(ifld) *
+     .                             (up(ix,ny,ifld) - up(ix,ny+1,ifld))
+                 elseif (isupwoix(ix,ifld)==3) then  # d(up)/dy = up/lyup
+                    yldot(iv2) = -nurlxu * nm(ix,ny,ifld) / fnorm(ifld) *
      .                             ( up(ix,ny+1,ifld) - up(ix,ny,ifld)*
      .                                (2*gyf(ix,ny)*lyup(2)-1)/
      .                                      (2*gyf(ix,ny)*lyup(2)+1) )
-               else
-                  yldot(iv2) = nurlxu * nm(ix,ny,ifld) / fnorm(ifld) *
+                 else
+                    yldot(iv2) = nurlxu * nm(ix,ny,ifld) / fnorm(ifld) *
      .                                      (0. - up(ix,ny+1,ifld))
+                 endif
                endif
             endif 
          enddo
@@ -2783,52 +2880,87 @@ ccc
 c... BC for neutral gas temperature/energy at iy=ny+1
           if (istgonxy(ix,ny+1,igsp) == 1) then
             iv = idxtg(ix,ny+1,igsp)
-            if (istgwcix(ix,igsp) == 0) then    # fixed Tg
-              yldot(iv) = nurlxg*(tgwall(igsp)*ev-tg(ix,ny+1,igsp))/
+            if (isvacuummodel(igsp) .gt. 0) then
+              fegytelemaxw(ix,igsp) = fngytelemaxw(ix,igsp)*2.*tg(ix,ny,igsp)
+              fegytelediff1(ix,igsp) = fngytelediff1(ix,igsp)*2.*tg(ix,ny,igsp)
+              fegytelediff2(ix,igsp) = fngytelediff2(ix,igsp)*2.5*tg(ix,ny,igsp)
+              fegytelediff3(ix,igsp) = fngytelediff3(ix,igsp)*2.5*tg(ix,ny,igsp)
+              fegytelediff(ix,igsp) = cfteleout*(fegytelediff1(ix,igsp) + fegytelediff2(ix,igsp) + fegytelediff3(ix,igsp))
+              # Trim diffusion to avoid negative influx
+              if (fngytelediff(ix,igsp) .gt. 0.) then
+                fteledifftrim = fegytelediff(ix,igsp)
+              else
+                fteledifftrim = 0.
+              endif
+              # compute fegyteleout
+              if (isvacuummodel(igsp) .eq. 1) then 
+                fegyteleout(ix,igsp) = fegytelemaxw(ix,igsp)
+              elseif (isvacuummodel(igsp) .eq. 2) then
+                fegyteleout(ix,igsp) = fteledifftrim
+              elseif (isvacuummodel(igsp) .eq. 3) then
+                if (Kn(ix,igsp) <= Knb1) then
+                  fegyteleout(ix,igsp) = fteledifftrim 
+                elseif (Kn(ix,igsp) >= Knb2) then
+                  fegyteleout(ix,igsp) = fegytelemaxw(ix,igsp)
+                else
+                  fegyteleout(ix,igsp) = (Kn(ix,igsp)-Knb1)/(Knb2-Knb1)*fegytelemaxw(ix,igsp) +
+     .                                   (Knb2-Kn(ix,igsp))/(Knb2-Knb1)*fteledifftrim
+                endif
+              else
+                write (*,*) 'isvacuummodel > 3 not available, placeholder for future extention'
+              endif
+              # place holder for momentu influx fmgytelein
+              fegytelein(ix,igsp) = 0.
+              yldot(iv) = nurlxg*( fegy(ix,ny,igsp) - (fegyteleout(ix,igsp)-fegytelein(ix,igsp)) )/
+     .                                      (sy(ix,ny)*vpnorm*ennorm)
+            else
+              if (istgwcix(ix,igsp) == 0) then    # fixed Tg
+                yldot(iv) = nurlxg*(tgwall(igsp)*ev-tg(ix,ny+1,igsp))/
      .                                                    (temp0*ev)
-            elseif (istgwcix(ix,igsp) == 1)    # extrapolation
-              tbound = tg(ix,ny,igsp) + gyf(ix,ny)*
-     .                     (tg(ix,ny,igsp)-tg(ix,ny-1,igsp))/gyf(ix,ny)
-              tbound = max(tbound, 0.25*tbmin*ev)  #tbmin=.1 eV
-              yldot(iv) = nurlxi *(tbound - tg(ix,ny+1,igsp))/(temp0*ev)
-            elseif (istgwcix(ix,igsp) == 2)    # specified gradient
-              yldot(iv) = nurlxi*( (tg(ix,ny,igsp) - tg(ix,ny+1,igsp)) -
-     .                         0.5*(tg(ix,ny,igsp) + tg(ix,ny+1,igsp))/
-     .                         (gyf(ix,ny)*lytg(2,igsp)) )/(temp0*ev)
-            elseif (istgwcix(ix,igsp) == 3)  #Maxwell thermal flux to wall
-              t0 = max(cdifg(igsp)*tg(ix,ny,igsp), temin*ev)
-              vyn = 0.25 * sqrt( 8*t0/(pi*mg(igsp)) )
-              yldot(iv) =  nurlxg*( fegy(ix,ny,igsp) - 2*cgengmw*
+              elseif (istgwcix(ix,igsp) == 1)    # extrapolation
+                tbound = tg(ix,ny,igsp) + gyf(ix,ny)*
+     .                       (tg(ix,ny,igsp)-tg(ix,ny-1,igsp))/gyf(ix,ny)
+                tbound = max(tbound, 0.25*tbmin*ev)  #tbmin=.1 eV
+                yldot(iv) = nurlxi *(tbound - tg(ix,ny+1,igsp))/(temp0*ev)
+              elseif (istgwcix(ix,igsp) == 2)    # specified gradient
+                yldot(iv) = nurlxi*( (tg(ix,ny,igsp) - tg(ix,ny+1,igsp)) -
+     .                           0.5*(tg(ix,ny,igsp) + tg(ix,ny+1,igsp))/
+     .                           (gyf(ix,ny)*lytg(2,igsp)) )/(temp0*ev)
+              elseif (istgwcix(ix,igsp) == 3)  #Maxwell thermal flux to wall
+                t0 = max(cdifg(igsp)*tg(ix,ny,igsp), temin*ev)
+                vyn = 0.25 * sqrt( 8*t0/(pi*mg(igsp)) )
+                yldot(iv) =  nurlxg*( fegy(ix,ny,igsp) - 2*cgengmw*
      .                              ng(ix,ny,igsp)*vyn*t0*sy(ix,ny) )/
      .                                      (sy(ix,ny)*vpnorm*ennorm)
-            elseif (istgwcix(ix,igsp) == 4) 
-	      t0 = max(tg(ix,ny+1,igsp),tgmin*ev)
-              vyn = sqrt( 0.5*t0/(pi*mg(igsp)) )
-              nharmave = 2.*(ng(ix,ny,igsp)*ng(ix,ny+1,igsp)) /
-     ,                      (ng(ix,ny,igsp)+ng(ix,ny+1,igsp))
-              fng_alb = (1-albedoo(ix,1))*nharmave*vyn*sy(ix,ny)
-              fng_chem = 0.
-              yldot(iv) = nurlxg*(fegy(ix,ny,igsp) - cfalbedo*fng_alb*t0
+              elseif (istgwcix(ix,igsp) == 4) 
+	        t0 = max(tg(ix,ny+1,igsp),tgmin*ev)
+                vyn = sqrt( 0.5*t0/(pi*mg(igsp)) )
+                nharmave = 2.*(ng(ix,ny,igsp)*ng(ix,ny+1,igsp)) /
+     ,                        (ng(ix,ny,igsp)+ng(ix,ny+1,igsp))
+                fng_alb = (1-albedoo(ix,1))*nharmave*vyn*sy(ix,ny)
+                fng_chem = 0.
+                yldot(iv) = nurlxg*(fegy(ix,ny,igsp) - cfalbedo*fng_alb*t0
      .                                             + 2.*fng_chem*t0)
-     .                                    /(vpnorm*ennorm*sy(ix,ny))
-              fniy_recy = 0.
-              if (matwallo(ix) .gt. 0) then
-                if (recycwot(ix,igsp) .gt. 0.) then
-                  fniy_recy = recycwot(ix,igsp)*fac2sp*fniy(ix,ny,1)
-                  if (isrefluxclip==1) fniy_recy=max(fniy_recy,0.)
-                  yldot(iv)=nurlxg*(fegy(ix,ny,igsp) - cfalbedo*fng_alb*t0
+     .                                      /(vpnorm*ennorm*sy(ix,ny))
+                fniy_recy = 0.
+                if (matwallo(ix) .gt. 0) then
+                  if (recycwot(ix,igsp) .gt. 0.) then
+                    fniy_recy = recycwot(ix,igsp)*fac2sp*fniy(ix,ny,1)
+                    if (isrefluxclip==1) fniy_recy=max(fniy_recy,0.)
+                    yldot(iv)=nurlxg*(fegy(ix,ny,igsp) - cfalbedo*fng_alb*t0
      .                                             + 2.*fng_chem*t0
      .                                             + fniy_recy*(1.-cfdiss)
      .                                              *cfalbedo*recycwe
      .                                              *ti(ix,ny) )
      .                                     /(vpnorm*ennorm*sy(ix,ny))
+                  endif
                 endif
+	      elseif (istgwc(igsp) == 5) then    # set tg=ti*cftgtiwc
+                yldot(iv) = nurlxg*(ti(ix,ny+1)*cftgtiwc(igsp) -
+     .                                     tg(ix,ny+1,igsp))/(temp0*ev)
+              elseif (istgwcix(ix,igsp) > 5)
+                 call xerrab("***Input error: invalid istgwc ***")
               endif
-	          elseif (istgwc(igsp) == 5) then    # set tg=ti*cftgtiwc
-              yldot(iv) = nurlxg*(ti(ix,ny+1)*cftgtiwc(igsp) -
-     .                                   tg(ix,ny+1,igsp))/(temp0*ev)
-            elseif (istgwcix(ix,igsp) > 5)
-               call xerrab("***Input error: invalid istgwc ***")
             endif
           endif
 

--- a/bbb/pandf_plasma_continuity.m
+++ b/bbb/pandf_plasma_continuity.m
@@ -296,7 +296,7 @@ c     Ionization of neutral hydrogen by electrons and recombination--
                psorbgg(ix,iy,igsp) = ngbackg(igsp)*( (0.9 + 0.1*
      .                            (ngbackg(igsp)/ng(ix,iy,igsp))**ingb) ) * 
      .                             nuiz(ix,iy,igsp) * vol(ix,iy)
-     .                                              * cfbackg(igsp)  #..zml
+     .                                              * cfbackg(igsp)  # ng numerical difficulty
                psorgc(ix,iy,igsp) = -ng(ix,iy,igsp)*nuiz(ix,iy,igsp)*vol(ix,iy) +
      .                              psorbgg(ix,iy,igsp)
                psorc(ix,iy,ifld) = - psorgc(ix,iy,igsp)
@@ -456,7 +456,7 @@ c              +n_(z+1)[ne K^r_(z+1)+ng K^cx_(z+1)]  # cx/r gain to z from z+1
 			 psorbgg(ix,iy,jg)= ngbackg(jg)*
      .                     (0.9+0.1*(ngbackg(jg)/ng(ix,iy,jg))**ingb) * 
      .                                                      nevol*kionz0
-     .                                                    * cfbackg(jg)  #..zml
+     .                                                    * cfbackg(jg)  # ng numerical difficulty
                          psorg(ix,iy,jg) = -ng(ix,iy,jg)*nevol*kionz0 +
      .                                      psorbgg(ix,iy,jg)
                          psor(ix,iy,ifld_fcs) = - psorg(ix,iy,jg)
@@ -681,7 +681,7 @@ c ...  molecule-molecule collisions would enter viscosity, not nuix
            psorbgg(ix,iy,2) = ngbackg(2)* 
      .                     (0.9+0.1*(ngbackg(2)/ng(ix,iy,2))**ingb ) * 
      .                                        nuiz(ix,iy,2) * vol(ix,iy)
-     .                                                      * cfbackg(2)  #..zml
+     .                                                      * cfbackg(2)  # ng numerical difficulty
            psorgc(ix,iy,2) = - ng(ix,iy,2)*nuiz(ix,iy,2)*vol(ix,iy) +
      .                        psorbgg(ix,iy,2)
                 psorg(ix,iy,2) = psorgc(ix,iy,2)  # no mol sor averaging

--- a/bbb/pandf_plasma_continuity.m
+++ b/bbb/pandf_plasma_continuity.m
@@ -296,6 +296,7 @@ c     Ionization of neutral hydrogen by electrons and recombination--
                psorbgg(ix,iy,igsp) = ngbackg(igsp)*( (0.9 + 0.1*
      .                            (ngbackg(igsp)/ng(ix,iy,igsp))**ingb) ) * 
      .                             nuiz(ix,iy,igsp) * vol(ix,iy)
+     .                                              * cfbackg(igsp)  #..zml
                psorgc(ix,iy,igsp) = -ng(ix,iy,igsp)*nuiz(ix,iy,igsp)*vol(ix,iy) +
      .                              psorbgg(ix,iy,igsp)
                psorc(ix,iy,ifld) = - psorgc(ix,iy,igsp)
@@ -455,6 +456,7 @@ c              +n_(z+1)[ne K^r_(z+1)+ng K^cx_(z+1)]  # cx/r gain to z from z+1
 			 psorbgg(ix,iy,jg)= ngbackg(jg)*
      .                     (0.9+0.1*(ngbackg(jg)/ng(ix,iy,jg))**ingb) * 
      .                                                      nevol*kionz0
+     .                                                    * cfbackg(jg)  #..zml
                          psorg(ix,iy,jg) = -ng(ix,iy,jg)*nevol*kionz0 +
      .                                      psorbgg(ix,iy,jg)
                          psor(ix,iy,ifld_fcs) = - psorg(ix,iy,jg)
@@ -679,6 +681,7 @@ c ...  molecule-molecule collisions would enter viscosity, not nuix
            psorbgg(ix,iy,2) = ngbackg(2)* 
      .                     (0.9+0.1*(ngbackg(2)/ng(ix,iy,2))**ingb ) * 
      .                                        nuiz(ix,iy,2) * vol(ix,iy)
+     .                                                      * cfbackg(2)  #..zml
            psorgc(ix,iy,2) = - ng(ix,iy,2)*nuiz(ix,iy,2)*vol(ix,iy) +
      .                        psorbgg(ix,iy,2)
                 psorg(ix,iy,2) = psorgc(ix,iy,2)  # no mol sor averaging


### PR DESCRIPTION
Add a few new functionality:

1. Add a coefficient _cfbackg_ for neutral background source _psorbgg_ to help relieve the numerical difficulty when ng is getting close to _ngbackg_, especially for impurity neutral continuity equations in more detached plasmas. Using _cfbackg[igsp] = 1.0_ is equivalent to default. Please use _10_ or _100_ which can help a lot sometime.

2. Add vacuum neutral model (VNM) to consider neutral bypassing through the vaccum ('void') region, from divertor regions to upstream, based on a DEGAS2 pre-calculated tele-transport matrix. The detailed instructions for using this model will be available soon. Please reach out to Andreas Holm or myself (zhao17@llnl) if you have questions.

3. Three options for computing out-going neutral fluxes for the above VNM are implemented:
    1) based on local half-Maxwellian assumption
    2) CX-diffusion assumption with local approximation
    3) combining the two based on local mean free path and density scale length
The Option 2 and 3 are based on the advanced neutral model developed by the KU Leuven group.